### PR TITLE
[fix-unmount] Fix argument passed into `cleanupView` in definition of…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ function render(
     baseElement,
     debug: (debugEl = baseElement, maxLength, options) =>
       console.log(prettyDOM(debugEl, maxLength, options)),
-    unmount: () => cleanupView(view),
+    unmount: () => cleanupView({ view, container }),
     ...getQueriesForElement(baseElement),
   };
 }


### PR DESCRIPTION
Fix argument passed into `cleanupView` in definition of `unmount` method to be a destructured object containing the required `view` and `container` objects.